### PR TITLE
Passthru pkgconfig tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,8 +177,6 @@ workflows:
   version: 2
   all-tests:
     jobs:
-      - "tests-353333"
-      - "tests-1909"
       - "tests-2009"
       - "tests-2105"
       - "package-macos":

--- a/challenge-bypass-ristretto.nix
+++ b/challenge-bypass-ristretto.nix
@@ -37,38 +37,41 @@ let
   # function (it was a set before, of course... maybe a "functor"?).
   buildRustCrate = args: buildRustCrateWithOverrides (args // { dontStrip = true; });
 
-  challenge-bypass-ristretto = pkgs.callPackage ./generated-challenge-bypass-ristretto.nix {
+  challenge-bypass-ristretto' = pkgs.callPackage ./generated-challenge-bypass-ristretto.nix {
     # Get all of the crates built with our preferences accounted for by
     # supplying our customized buildRustCrate.
     inherit buildRustCrate;
   };
-in
-challenge-bypass-ristretto.rootCrate.build.overrideAttrs (old: rec {
-  pname = "libchallenge_bypass_ristretto_ffi";
-  # Version constrained by
-  # https://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Version.html
-  # until you upgrade to Cabal 3.0.0.
-  version = "1.0.0-pre3";
 
-  # crate2nix generates expressions that want to use the local source files.
-  # Git submodules make everything more complicated though so I'd rather just
-  # always say we built from the canonical revision from Github.  Override the
-  # src defined in the generated expression to say that.
-  src = pkgs.fetchFromGitHub {
-    owner = "brave-intl";
-    repo = "challenge-bypass-ristretto-ffi";
-    rev = "f88d942ddfaf61a4a6703355a77c4ef71bc95c35";
-    sha256 = "1gf7ki3q6d15bq71z8s3pc5l2rsp1zk5bqviqlwq7czg674g7zw2";
-  };
+  # Note: challenge-bypass-ristretto and tests are mutually recursive because
+  # tests needs the lib output but needs to be defined inside the derivation
+  # itself.
+  challenge-bypass-ristretto = challenge-bypass-ristretto'.rootCrate.build.overrideAttrs (old: rec {
+    pname = "libchallenge_bypass_ristretto_ffi";
+    # Version constrained by
+    # https://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Version.html
+    # until you upgrade to Cabal 3.0.0.
+    version = "1.0.0-pre3";
 
-  postInstall = ''
-  # Provide the ffi header file things can be compiled against the library.
-  mkdir -p $lib/include
-  cp src/lib.h $lib/include/
+    # crate2nix generates expressions that want to use the local source files.
+    # Git submodules make everything more complicated though so I'd rather just
+    # always say we built from the canonical revision from Github.  Override the
+    # src defined in the generated expression to say that.
+    src = pkgs.fetchFromGitHub {
+      owner = "brave-intl";
+      repo = "challenge-bypass-ristretto-ffi";
+      rev = "f88d942ddfaf61a4a6703355a77c4ef71bc95c35";
+      sha256 = "1gf7ki3q6d15bq71z8s3pc5l2rsp1zk5bqviqlwq7czg674g7zw2";
+    };
 
-  # Provide a pkgconfig file so build systems can find the header and library.
-  mkdir -p $lib/lib/pkgconfig
-  cat > $lib/lib/pkgconfig/${pname}.pc <<EOF
+    postInstall = ''
+    # Provide the ffi header file things can be compiled against the library.
+    mkdir -p $lib/include
+    cp src/lib.h $lib/include/
+
+    # Provide a pkgconfig file so build systems can find the header and library.
+    mkdir -p $lib/lib/pkgconfig
+    cat > $lib/lib/pkgconfig/${pname}.pc <<EOF
 prefix=$lib
 exec_prefix=$lib
 libdir=$lib
@@ -83,19 +86,37 @@ Requires:
 Libs: -L$lib -lchallenge_bypass_ristretto_ffi
 Cflags: -I$lib/include
 EOF
-  '';
-
-  passthru.tests = {
-    simple = pkgs.runCommand "${pname}-tests" {} ''
-    # Verify that we are supplying the dynamic libraries in a discoverable way.
-    if ! ${pkgs.pkg-config}/bin/pkg-config --exists ${pname}; then
-      echo "Failed to discover ${pname} with pkg-config"
-      exit 1
-    fi
-    if ! ${pkgs.pkg-config}/bin/pkg-config --validate ${pname}; then
-      echo "Failed to validate ${pname}.pc with pkg-config"
-      exit 1
-    fi
     '';
+    passthru = {
+      inherit tests;
+    };
+  });
+
+  tests =
+    let
+      inherit (challenge-bypass-ristretto) pname;
+    in
+      {
+        simple = pkgs.runCommand "${pname}-tests" {
+          nativeBuildInputs = [
+            # Putting pkg-config here causes the hooks that set
+            # PKG_CONFIG_PATH to be set.
+            pkgs.pkg-config
+            challenge-bypass-ristretto.lib
+          ];
+        } ''
+# Verify that we are supplying the dynamic libraries in a discoverable way.
+if ! pkg-config --exists ${pname}; then
+  echo "Failed to discover ${pname} with pkg-config"
+  exit 1
+fi
+if ! pkg-config --validate ${pname}; then
+  echo "Failed to validate ${pname}.pc with pkg-config"
+  exit 1
+fi
+echo "passed" > "$out"
+'';
   };
-})
+
+in
+challenge-bypass-ristretto

--- a/challenge-bypass-ristretto.nix
+++ b/challenge-bypass-ristretto.nix
@@ -1,4 +1,4 @@
-{ pkgs, stdenv, lib, darwin }:
+{ pkgs, stdenv ? pkgs.stdenv, lib ? pkgs.lib, darwin ? pkgs.darwin }:
 let
   withSecurity = attrs: {
     buildInputs = lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
@@ -84,4 +84,18 @@ Libs: -L$lib -lchallenge_bypass_ristretto_ffi
 Cflags: -I$lib/include
 EOF
   '';
+
+  passthru.tests = {
+    simple = pkgs.runCommand "${pname}-tests" {} ''
+    # Verify that we are supplying the dynamic libraries in a discoverable way.
+    if ! ${pkgs.pkg-config}/bin/pkg-config --exists ${pname}; then
+      echo "Failed to discover ${pname} with pkg-config"
+      exit 1
+    fi
+    if ! ${pkgs.pkg-config}/bin/pkg-config --validate ${pname}; then
+      echo "Failed to validate ${pname}.pc with pkg-config"
+      exit 1
+    fi
+    '';
+  };
 })

--- a/ci-tools/run-tests.sh
+++ b/ci-tools/run-tests.sh
@@ -2,16 +2,7 @@
 
 set -euxo pipefail
 
-# An explicit build step so build failures can be seen separately from the rest.
-LIB=$(nix-build default-challenge-bypass-ristretto-ffi.nix -A lib)
-
-# Check to see if we successfully exported the pkg-config configuration.
-# `--exists` will exit with error status if we have not.  It might be better
-# if this were the checkPhase for the ffi bindings derivation.
-if ! nix-shell -p "${LIB}" pkg-config --run 'pkg-config --exists libchallenge_bypass_ristretto_ffi'; then
-    echo "pkg-config does not know about the library"
-    exit 1
-fi
+nix-build --arg pkgs 'import <nixpkgs> {}' challenge-bypass-ristretto.nix -A tests
 
 # Run what passes for the test suite for our Python code, too.  Ditto here
 # about checkPhase.


### PR DESCRIPTION
This puts the pkg-config-related checks of the Nix package inside the Nix package definition.  This seems mildly cleaner than having a random extra script that runs on CI.  Also I forgot about the CI script until I had already finished adding these tests to the Nix package definition...
