### PR TITLE
Support Python3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,26 +22,6 @@ commands:
         type: "string"
         default: "python3"
 
-    environment:
-      # PyPI authentication configuration for twine so we can upload packages.
-      # TWINE_PASSWORD is set in the CircleCI private configuration section.
-      # In the CircleCI web app:
-      #
-      #    Project Settings ->
-      #    Environment Variables ->
-      #    Add Environment Variable ->
-      #    Name: TWINE_PASSWORD
-      #    Value: <a token issued by PyPI>
-      #
-      # The PyPI token is issued in the PyPI web app:
-      #
-      #    Manage ->
-      #    Settings ->
-      #    Create a token for ... ->
-      #    Permissions: Upload
-      #    Scope: Project: python-challenge-bypass-ristretto
-      TWINE_USERNAME: "__token__"
-
     steps:
       - "checkout"
       - run:
@@ -88,6 +68,26 @@ commands:
 
       - run:
           name: "Upload Wheel"
+          environment:
+            # PyPI authentication configuration for twine so we can upload
+            # packages.  TWINE_PASSWORD is set in the CircleCI private
+            # configuration section.  In the CircleCI web app:
+            #
+            #    Project Settings ->
+            #    Environment Variables ->
+            #    Add Environment Variable ->
+            #    Name: TWINE_PASSWORD
+            #    Value: <a token issued by PyPI>
+            #
+            # The PyPI token is issued in the PyPI web app:
+            #
+            #    Manage ->
+            #    Settings ->
+            #    Create a token for ... ->
+            #    Permissions: Upload
+            #    Scope: Project: python-challenge-bypass-ristretto
+            TWINE_USERNAME: "__token__"
+
           command: |
             if [[ "$CIRCLE_TAG" == v* ]]; then
               # We're building a release tag so we should probably really

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,18 +11,6 @@ executors:
     docker:
       - image: "quay.io/pypa/manylinux_2_24_x86_64"
 
-  # Since this executor doesn't use a pypa-defined image created specifically
-  # for building wheels, we're a little bit less confident of exactly what
-  # kind of manylinux wheel will come out of it.  x_y here is a reference to
-  # the "future-proof" (heh) PEP 600 manylinux definition.  For a given pinned
-  # image, we should probably always get the same version out (eg
-  # manylinux_2_17 as of ubuntu-2004:202101-01) but if glibc on the system is
-  # upgraded then we'll probably get higher numbers.
-  manylinux_x_y-aarch64:
-    machine:
-      image: "ubuntu-2004:202101-01"
-    resource_class: "arm.large"
-
 # Define some custom commands that we can use as elements of `steps` in job
 # definitions.
 commands:
@@ -288,15 +276,6 @@ workflows:
           # Similar to the manylinux-2014_x86_64 case.
           pre-command: "apt-get update -y && apt-get install -y openssh-client"
           python: "/opt/python/cp37-cp37m/bin/python"
-      - "package-manylinux":
-          name: "package-manylinux_x_y-aarch64"
-          executor: "manylinux_x_y-aarch64"
-          # The image this executor uses has an ssh client but is missing the
-          # patchelf tool required by auditwheel.
-          pre-command: |
-            sudo apt-get update
-            sudo apt-get install patchelf
-          python: "python3"
 
       - "package-macos":
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,11 @@ version: 2.1
 
 commands:
   build-wheel:
+    parameters:
+      python:
+        description: "The path to the Python executable to use"
+        type: "string"
+
     description: "Build a Python wheel"
     steps:
       - "checkout"
@@ -24,17 +29,17 @@ commands:
           name: "Get Python Build/Package Dependencies"
           command: |
             # Make sure we have a pip that's aware of Python version constraints
-            python3 -m pip install --upgrade pip
+            << parameters.python >> -m pip install --upgrade pip
             # Pre-install these two setup_depends using pip so we don't have
             # to rely on whatever resolution logic setuptools would apply.
-            python3 -m pip install --upgrade milksnake setuptools_scm
+            << parameters.python >> -m pip install --upgrade milksnake setuptools_scm
             # And get these so we can build and then upload a wheel
-            python3 -m pip install wheel twine
+            << parameters.python >> -m pip install wheel twine
 
       - run:
           name: "Build Wheel"
           command: |
-            python3 setup.py bdist_wheel
+            << parameters.python >> setup.py bdist_wheel
 
       - run:
           name: "Upload Wheel"
@@ -50,10 +55,15 @@ commands:
               repo="testpypi"
               TWINE_PASSWORD="$TWINE_TESTPYPI_PASSWORD"
             fi
-            python3 -m twine upload --repository $repo dist/*
+            << parameters.python >> -m twine upload --repository $repo dist/*
 
 jobs:
-  package-manylinux2014_x86_64:
+  package-manylinux:
+    parameters:
+      python:
+        description: "The path to the Python executable to use"
+        type: "string"
+
     environment:
       # PyPI authentication configuration for twine so we can upload packages.
       # TWINE_PASSWORD is set in the CircleCI private configuration section.
@@ -75,7 +85,7 @@ jobs:
       TWINE_USERNAME: "__token__"
 
     docker:
-      - image: "quay.io/pypa/manylinux2014_x86_64"
+      - image: "<< parameters.image >>"
 
     steps:
       # The build needs SSH to update the submodule.
@@ -197,7 +207,12 @@ workflows:
     jobs:
       - "tests-2105"
       - "tests-2111"
-      - "package-manylinux2014_x86_64"
+      - "package-manylinux":
+          matrix:
+            parameters:
+              - image: "quay.io/pypa/manylinux2014_x86_64"
+                python: "/opt/python/cp37-cp37m/bin/python"
+
       - "package-macos":
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
   manylinux_2_24-aarch64:
     machine:
       image: "ubuntu-2004:202101-01"
-    resource_class: "arm.medium"
+    resource_class: "arm.large"
 
 commands:
   build-wheel:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,8 @@ jobs:
             yum install -y openssh-clients
 
       - "build-wheel":
-          python: "<< parameters.python >>"
+          parameters:
+            python: "<< parameters.python >>"
 
   package-macos:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ commands:
             python3 -m twine upload --repository $repo dist/*
 
 jobs:
-  package-manylinux1:
+  package-manylinux2010:
     environment:
       # PyPI authentication configuration for twine so we can upload packages.
       # TWINE_PASSWORD is set in the CircleCI private configuration section.
@@ -75,21 +75,14 @@ jobs:
       TWINE_USERNAME: "__token__"
 
     docker:
-      - image: "quay.io/pypa/manylinux1_x86_64"
+      - image: "quay.io/pypa/manylinux2010_x86_64"
 
     steps:
-      # The build needs SSH to update the submodule.
-      - run:
-          name: "Install SSH Client"
-          command: |
-            yum install -y openssh-clients
-
-      # Now build the wheel.
       - "build-wheel"
 
   package-macos:
     environment:
-      # See package-manylinux1
+      # See package-manylinux2010
       TWINE_USERNAME: "__token__"
 
     parameters:
@@ -198,7 +191,7 @@ workflows:
     jobs:
       - "tests-2105"
       - "tests-2111"
-      - "package-manylinux1"
+      - "package-manylinux2010"
       - "package-macos":
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,8 @@ commands:
             case "${CIRCLE_JOB}" in
               *manylinux*)
                 << parameters.python >> -m auditwheel repair python_challenge_bypass_ristretto*.whl
+                rm *.whl
+                mv wheelhouse/python_challenge_bypass_ristretto*.whl ./
                 ;;
             esac
 
@@ -65,7 +67,7 @@ commands:
               repo="testpypi"
               TWINE_PASSWORD="$TWINE_TESTPYPI_PASSWORD"
             fi
-            << parameters.python >> -m twine upload --repository $repo wheelhouse/python_challenge_bypass_ristretto*.whl
+            << parameters.python >> -m twine upload --repository $repo python_challenge_bypass_ristretto*.whl
 
 jobs:
   package-manylinux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 executors:
-  manylinux-2014_x86_64:
+  manylinux-2014-x86_64:
     docker:
       - image: "quay.io/pypa/manylinux2014_x86_64"
   manylinux_2_24-x86_64:
@@ -236,12 +236,12 @@ workflows:
       - "tests-2111"
       - "package-manylinux":
           name: "package-manylinux-2014_x86_64"
-          executor: "manylinux-2014_x86_64"
+          executor: "manylinux-2014-x86_64"
           install-ssh-client: "yum install -y openssh-clients"
           python: "/opt/python/cp37-cp37m/bin/python"
       - "package-manylinux":
           name: "package-manylinux_2_24-x86_64"
-          executor: "manylinux_2_24_x86_64"
+          executor: "manylinux_2_24-x86_64"
           python: "/opt/python/cp37-cp37m/bin/python"
       # - "package-manylinux":
       #     name: "package-manylinux_2_24-aarch64"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ jobs:
       install-ssh-client:
         description: "a command to install an SSH client prior to cloning git repositoties"
         type: "string"
+        default: ""
 
       python:
         description: "the path to the Python executable to use"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,17 +50,17 @@ jobs:
           name: "Get Python Build/Package Dependencies"
           command: |
             # Make sure we have a pip that's aware of Python version constraints
-            pip install --upgrade pip
+            python3 -m pip install --upgrade pip
             # Pre-install these two setup_depends using pip so we don't have
             # to rely on whatever resolution logic setuptools would apply.
-            pip install --upgrade milksnake setuptools_scm
+            python3 -m pip install --upgrade milksnake setuptools_scm
             # And get these so we can build and then upload a wheel
-            pip install wheel twine
+            python3 -m pip install wheel twine
 
       - run:
           name: "Build Wheel"
           command: |
-            python setup.py bdist_wheel
+            python3 setup.py bdist_wheel
 
       - run:
           name: "Upload Wheel"
@@ -76,7 +76,7 @@ jobs:
               repo="testpypi"
               TWINE_PASSWORD="$TWINE_TESTPYPI_PASSWORD"
             fi
-            python -m twine upload --repository $repo dist/*
+            python3 -m twine upload --repository $repo dist/*
 
   tests-template: &TESTS
     docker:
@@ -179,10 +179,10 @@ workflows:
             parameters:
               # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
               xcode-version:
-                # Latest macOS 10.14
-                - "11.1.0"
-                # The newest macOS 10.15 that still has Python 2. :/
-                - "11.4.1"
+                # Latest macOS 10.x
+                - "12.4.0"
+                # Latest macOS 11.x
+                - "13.2.1"
           filters:
             # CircleCI does not run workflows for tags unless you explicitly
             # specify tag filters. Additionally, if a job requires any other

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,8 @@
 version: 2.1
 
-jobs:
-  package-template: &PACKAGE_TEMPLATE
-    environment:
-      # PyPI authentication configuration for twine so we can upload packages.
-      # TWINE_PASSWORD is set in the CircleCI private configuration section.
-      # In the CircleCI web app:
-      #
-      #    Project Settings ->
-      #    Environment Variables ->
-      #    Add Environment Variable ->
-      #    Name: TWINE_PASSWORD
-      #    Value: <a token issued by PyPI>
-      #
-      # The PyPI token is issued in the PyPI web app:
-      #
-      #    Manage ->
-      #    Settings ->
-      #    Create a token for ... ->
-      #    Permissions: Upload
-      #    Scope: Project: python-challenge-bypass-ristretto
-      TWINE_USERNAME: "__token__"
-
+commands:
+  build-wheel:
+    description: "Build a Python wheel"
     steps:
       - "checkout"
       - run:
@@ -71,15 +52,38 @@ jobs:
             fi
             python3 -m twine upload --repository $repo dist/*
 
-
+jobs:
   package-ubuntu:
-    <<: *PACKAGE_TEMPLATE
+    environment:
+      # PyPI authentication configuration for twine so we can upload packages.
+      # TWINE_PASSWORD is set in the CircleCI private configuration section.
+      # In the CircleCI web app:
+      #
+      #    Project Settings ->
+      #    Environment Variables ->
+      #    Add Environment Variable ->
+      #    Name: TWINE_PASSWORD
+      #    Value: <a token issued by PyPI>
+      #
+      # The PyPI token is issued in the PyPI web app:
+      #
+      #    Manage ->
+      #    Settings ->
+      #    Create a token for ... ->
+      #    Permissions: Upload
+      #    Scope: Project: python-challenge-bypass-ristretto
+      TWINE_USERNAME: "__token__"
 
     docker:
       - image: "circleci/python:3.9"
 
+    steps:
+      - "build-wheel"
+
   package-macos:
-    <<: *PACKAGE_TEMPLATE
+    environment:
+      # See package-ubuntu
+      TWINE_USERNAME: "__token__"
 
     parameters:
       xcode-version:
@@ -88,6 +92,8 @@ jobs:
     macos:
       xcode: "<< parameters.xcode-version >>"
 
+    steps:
+      - "build-wheel"
 
   tests-template: &TESTS
     docker:
@@ -185,6 +191,7 @@ workflows:
     jobs:
       - "tests-2105"
       - "tests-2111"
+      - "package-ubuntu"
       - "package-macos":
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
 
   package-macos:
     environment:
-      # See package-ubuntu
+      # See package-manylinux1
       TWINE_USERNAME: "__token__"
 
     parameters:
@@ -191,7 +191,7 @@ workflows:
     jobs:
       - "tests-2105"
       - "tests-2111"
-      - "package-ubuntu"
+      - "package-manylinux1"
       - "package-macos":
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,13 @@ commands:
           name: "Install Rust Build Toolchain"
           command: |
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup-init
-            sh /tmp/rustup-init -y --default-toolchain stable
+            for i in $(seq 10); do
+                if sh /tmp/rustup-init -y --default-toolchain stable; then
+                    break
+                else
+                    sleep 1
+                fi
+            done
             echo '. "$HOME"/.cargo/env' >> $BASH_ENV
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ commands:
       - run:
           name: "Build Wheel"
           command: |
-            << parameters.python >> setup.py bdist_wheel
+            << parameters.python >> -m pip wheel .
 
       - run:
           name: "Upload Wheel"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,9 @@ jobs:
       - run:
           name: "Install SSH Client"
           command: |
-            yum install -y openssh-clients
+            if [ -e yum ]; then
+                yum install -y openssh-clients
+            fi
 
       - "build-wheel":
           python: "<< parameters.python >>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ commands:
               repo="testpypi"
               TWINE_PASSWORD="$TWINE_TESTPYPI_PASSWORD"
             fi
-            << parameters.python >> -m twine upload --repository $repo python_challenge_bypass_ristretto*.whl
+            << parameters.python >> -m twine upload --repository $repo wheelhouse/python_challenge_bypass_ristretto*.whl
 
 jobs:
   package-manylinux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,13 @@ jobs:
       - image: "quay.io/pypa/manylinux1_x86_64"
 
     steps:
+      # The build needs SSH to update the submodule.
+      - run:
+          name: "Install SSH Client"
+          command: |
+            yum install -y openssh-clients
+
+      # Now build the wheel.
       - "build-wheel"
 
   package-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,10 +212,9 @@ workflows:
       - "tests-2105"
       - "tests-2111"
       - "package-manylinux":
-          matrix:
-            parameters:
-              image: "quay.io/pypa/manylinux2014_x86_64"
-              python: "/opt/python/cp37-cp37m/bin/python"
+          name: "package-manylinux-2014_x86_64"
+          image: "quay.io/pypa/manylinux2014_x86_64"
+          python: "/opt/python/cp37-cp37m/bin/python"
 
       - "package-macos":
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,10 @@ commands:
         type: "string"
         default: "python3"
 
+      audit-wheel:
+        description: "A boolean controlling whether the auditwheel tool is used to fix up the wheel"
+        type: "boolean"
+
     steps:
       - "checkout"
       - run:
@@ -74,22 +78,21 @@ commands:
           command: |
             << parameters.python >> -m pip wheel --no-deps .
 
-      - run:
-          name: "Audix / Fix Wheel "
-          command: |
-            # Since both macOS and Linux jobs re-use this step, make sure we
-            # only try to use auditwheel on the appropriate platform.  That
-            # is, only on Linux.
-            case "${CIRCLE_JOB}" in
-              *manylinux*)
-                << parameters.python >> -m auditwheel repair python_challenge_bypass_ristretto*.whl
-                # Delete the original, unfixed wheel.
-                rm *.whl
-                # Move the fixed wheel here for consistency with the
-                # non-manylinux case.
-                mv wheelhouse/python_challenge_bypass_ristretto*.whl ./
-                ;;
-            esac
+      - when:
+          condition: << parameters.audit-wheel >>
+          steps:
+            - run:
+                name: "Audix / Fix Wheel"
+                command: |
+                  # Since both macOS and Linux jobs re-use this step, make
+                  # sure we only try to use auditwheel on the appropriate
+                  # platform.  That is, only on Linux.
+                  << parameters.python >> -m auditwheel repair python_challenge_bypass_ristretto*.whl
+                  # Delete the original, unfixed wheel.
+                  rm *.whl
+                  # Move the fixed wheel here for consistency with the
+                  # non-manylinux case.
+                  mv wheelhouse/python_challenge_bypass_ristretto*.whl ./
 
       - run:
           name: "Upload Wheel"
@@ -160,6 +163,7 @@ jobs:
 
       - "build-wheel":
           python: "<< parameters.python >>"
+          audit-wheel: true
 
   package-macos:
     parameters:
@@ -170,7 +174,9 @@ jobs:
       xcode: "<< parameters.xcode-version >>"
 
     steps:
-      - "build-wheel"
+      - "build-wheel":
+          audit-wheel: false
+
 
   tests-template: &TESTS
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,11 +158,6 @@ jobs:
           command: |
             ./ci-tools/run-tests.sh
 
-  tests-2009:
-    <<: *TESTS
-    environment:
-      NIXPKGS_REV: "20.09"
-
   tests-2105:
     <<: *TESTS
     environment:
@@ -177,7 +172,6 @@ workflows:
   version: 2
   all-tests:
     jobs:
-      - "tests-2009"
       - "tests-2105"
       - "tests-2111"
       - "package-macos":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             fi
             python -m twine upload --repository $repo dist/*
 
-  tests-353333: &TESTS
+  tests-template: &TESTS
     docker:
       # Run in a highly Nix-capable environment.
       - image: "nixorg/nix:circleci"
@@ -90,7 +90,7 @@ jobs:
       # time of this comment.  We can bump it to a newer version when that
       # makes sense.  Meanwhile, the platform won't shift around beneath us
       # unexpectedly.
-      NIXPKGS_REV: "353333ef340952c05332e3c271dff953264cb017"
+      NIXPKGS_REV: "XXX" # Set this in a derived environment.
 
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,14 @@ workflows:
           name: "package-manylinux-2014_x86_64"
           image: "quay.io/pypa/manylinux2014_x86_64"
           python: "/opt/python/cp37-cp37m/bin/python"
+      - "package-manylinux":
+          name: "package-manylinux_2_24-x86_64"
+          image: "quay.io/pypa/manylinux_2_24_x86_64"
+          python: "/opt/python/cp37-cp37m/bin/python"
+      - "package-manylinux":
+          name: "package-manylinux_2_24-aarch64"
+          image: "quay.io/pypa/manylinux_2_24_aarch64"
+          python: "/opt/python/cp37-cp37m/bin/python"
 
       - "package-macos":
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,9 +76,8 @@ jobs:
         description: "The path to the Python executable to use"
         type: "string"
 
-      image:
-        description: "The Docker image to use"
-        type: "string"
+      executor:
+        type: "executor"
 
     environment:
       # PyPI authentication configuration for twine so we can upload packages.
@@ -100,8 +99,7 @@ jobs:
       #    Scope: Project: python-challenge-bypass-ristretto
       TWINE_USERNAME: "__token__"
 
-    docker:
-      - image: "<< parameters.image >>"
+    executor: "<< parameters.executor >>"
 
     steps:
       # The build needs SSH to update the submodule.
@@ -228,16 +226,19 @@ workflows:
       - "tests-2111"
       - "package-manylinux":
           name: "package-manylinux-2014_x86_64"
-          image: "quay.io/pypa/manylinux2014_x86_64"
           python: "/opt/python/cp37-cp37m/bin/python"
-      - "package-manylinux":
-          name: "package-manylinux_2_24-x86_64"
-          image: "quay.io/pypa/manylinux_2_24_x86_64"
-          python: "/opt/python/cp37-cp37m/bin/python"
-      - "package-manylinux":
-          name: "package-manylinux_2_24-aarch64"
-          image: "quay.io/pypa/manylinux_2_24_aarch64"
-          python: "/opt/python/cp37-cp37m/bin/python"
+          executor:
+            docker:
+              - image: "quay.io/pypa/manylinux2014_x86_64"
+
+      # - "package-manylinux":
+      #     name: "package-manylinux_2_24-x86_64"
+      #     image: "quay.io/pypa/manylinux_2_24_x86_64"
+      #     python: "/opt/python/cp37-cp37m/bin/python"
+      # - "package-manylinux":
+      #     name: "package-manylinux_2_24-aarch64"
+      #     image: "quay.io/pypa/manylinux_2_24_aarch64"
+      #     python: "/opt/python/cp37-cp37m/bin/python"
 
       - "package-macos":
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,10 @@ jobs:
         description: "The path to the Python executable to use"
         type: "string"
 
+      image:
+        description: "The Docker image to use"
+        type: "string"
+
     environment:
       # PyPI authentication configuration for twine so we can upload packages.
       # TWINE_PASSWORD is set in the CircleCI private configuration section.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,6 +243,7 @@ workflows:
       - "package-manylinux":
           name: "package-manylinux_2_24-x86_64"
           executor: "manylinux_2_24-x86_64"
+          install-ssh-client: "apt-get install -y openssh-client"
           python: "/opt/python/cp37-cp37m/bin/python"
       # - "package-manylinux":
       #     name: "package-manylinux_2_24-aarch64"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,11 +158,6 @@ jobs:
           command: |
             ./ci-tools/run-tests.sh
 
-  tests-1909:
-    <<: *TESTS
-    environment:
-      NIXPKGS_REV: "19.09"
-
   tests-2009:
     <<: *TESTS
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+# Define executors that various packaging jobs need.  This lets us make one
+# packaging job that accepts an executor parameter and avoids duplicating the
+# packaging steps.
 executors:
   manylinux-2014-x86_64:
     docker:
@@ -7,11 +10,21 @@ executors:
   manylinux_2_24-x86_64:
     docker:
       - image: "quay.io/pypa/manylinux_2_24_x86_64"
-  manylinux_2_24-aarch64:
+
+  # Since this executor doesn't use a pypa-defined image created specifically
+  # for building wheels, we're a little bit less confident of exactly what
+  # kind of manylinux wheel will come out of it.  x_y here is a reference to
+  # the "future-proof" (heh) PEP 600 manylinux definition.  For a given pinned
+  # image, we should probably always get the same version out (eg
+  # manylinux_2_17 as of ubuntu-2004:202101-01) but if glibc on the system is
+  # upgraded then we'll probably get higher numbers.
+  manylinux_x_y-aarch64:
     machine:
       image: "ubuntu-2004:202101-01"
     resource_class: "arm.large"
 
+# Define some custom commands that we can use as elements of `steps` in job
+# definitions.
 commands:
   build-wheel:
     description: "Build a Python wheel"
@@ -58,10 +71,16 @@ commands:
       - run:
           name: "Audix / Fix Wheel "
           command: |
+            # Since both macOS and Linux jobs re-use this step, make sure we
+            # only try to use auditwheel on the appropriate platform.  That
+            # is, only on Linux.
             case "${CIRCLE_JOB}" in
               *manylinux*)
                 << parameters.python >> -m auditwheel repair python_challenge_bypass_ristretto*.whl
+                # Delete the original, unfixed wheel.
                 rm *.whl
+                # Move the fixed wheel here for consistency with the
+                # non-manylinux case.
                 mv wheelhouse/python_challenge_bypass_ristretto*.whl ./
                 ;;
             esac
@@ -102,14 +121,21 @@ commands:
             fi
             << parameters.python >> -m twine upload --repository $repo python_challenge_bypass_ristretto*.whl
 
+# Define the actual jobs that will be available to run in a workflow.
 jobs:
+
+  # Build a manylinux wheel.
   package-manylinux:
     parameters:
       executor:
+        # note the name comes from the `executors` section above
+        description: "the name of the executor to use to run this job"
         type: "executor"
 
-      install-ssh-client:
-        description: "a command to install an SSH client prior to cloning git repositoties"
+      pre-command:
+        description: |
+          a command to run first which resolves any inconsistencies between
+          the chosen executor and the requirements of this job
         type: "string"
         default: ""
 
@@ -121,11 +147,10 @@ jobs:
     executor: "<< parameters.executor >>"
 
     steps:
-      # The build needs SSH to update the submodule.
       - run:
-          name: "Install SSH Client"
+          name: "Prepare Execution Environment"
           command: |
-            << parameters.install-ssh-client >>
+            << parameters.pre-command >>
 
       - "build-wheel":
           python: "<< parameters.python >>"
@@ -240,19 +265,24 @@ workflows:
       - "package-manylinux":
           name: "package-manylinux-2014_x86_64"
           executor: "manylinux-2014-x86_64"
-          install-ssh-client: "yum install -y openssh-clients"
+          # The image this executor uses comes with no ssh client.  CircleCI
+          # rewrites our git configuration to fetch sources over ssh.  Then it
+          # fails if we don't have any ssh client.
+          pre-command: "yum install -y openssh-clients"
           python: "/opt/python/cp37-cp37m/bin/python"
       - "package-manylinux":
           name: "package-manylinux_2_24-x86_64"
           executor: "manylinux_2_24-x86_64"
-          install-ssh-client: "apt-get update -y && apt-get install -y openssh-client"
+          # Similar to the manylinux-2014_x86_64 case.
+          pre-command: "apt-get update -y && apt-get install -y openssh-client"
           python: "/opt/python/cp37-cp37m/bin/python"
       - "package-manylinux":
-          name: "package-manylinux_2_24-aarch64"
-          executor: "manylinux_2_24-aarch64"
-          install-ssh-client: |
+          name: "package-manylinux_x_y-aarch64"
+          executor: "manylinux_x_y-aarch64"
+          # The image this executor uses has an ssh client but is missing the
+          # patchelf tool required by auditwheel.
+          pre-command: |
             sudo apt-get update
-            # an auditwheel dependency that's not installed by default
             sudo apt-get install patchelf
           python: "python3"
 
@@ -261,12 +291,12 @@ workflows:
             parameters:
               # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
               xcode-version:
+                # Latest macOS 10.14.x
+                - "11.1.0"
                 # Latest macOS 10.15.x
                 - "12.4.0"
                 # Latest macOS 11.x
                 - "13.2.1"
-                # Just see if we can still have a 10.14.x
-                - "11.1.0"
           filters:
             # CircleCI does not run workflows for tags unless you explicitly
             # specify tag filters. Additionally, if a job requires any other

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,8 @@ jobs:
           command: |
             yum install -y openssh-clients
 
-      - "build-wheel"
+      - "build-wheel":
+          python: "<< parameters.python >>"
 
   package-macos:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,7 +252,9 @@ workflows:
       - "package-manylinux":
           name: "package-manylinux_2_24-aarch64"
           executor: "manylinux_2_24-aarch64"
-          install-ssh-client: "apt-get update -y && apt-get install -y openssh-client"
+          install-ssh-client: |
+            sudo apt-get update -y
+            sudo apt-get install -y openssh-client
           python: "python3"
 
       - "package-macos":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,10 @@ executors:
   manylinux_2_24-x86_64:
     docker:
       - image: "quay.io/pypa/manylinux_2_24_x86_64"
+  manylinux_2_24-aarch64:
+    machine:
+      image: "ubuntu-2004:202101-01"
+    resource_class: "arm.medium"
 
 commands:
   build-wheel:
@@ -245,10 +249,11 @@ workflows:
           executor: "manylinux_2_24-x86_64"
           install-ssh-client: "apt-get update -y && apt-get install -y openssh-client"
           python: "/opt/python/cp37-cp37m/bin/python"
-      # - "package-manylinux":
-      #     name: "package-manylinux_2_24-aarch64"
-      #     image: "quay.io/pypa/manylinux_2_24_aarch64"
-      #     python: "/opt/python/cp37-cp37m/bin/python"
+      - "package-manylinux":
+          name: "package-manylinux_2_24-aarch64"
+          executor: "manylinux_2_24-aarch64"
+          install-ssh-client: "apt-get update -y && apt-get install -y openssh-client"
+          python: "python3"
 
       - "package-macos":
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,11 @@ commands:
       - run:
           name: "Audix / Fix Wheel "
           command: |
-            << parameters.python >> -m auditwheel repair python_challenge_bypass_ristretto*.whl
+            case "${CIRCLE_JOB}" in
+              *manylinux*)
+                << parameters.python >> -m auditwheel repair python_challenge_bypass_ristretto*.whl
+                ;;
+            esac
 
       - run:
           name: "Upload Wheel"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ commands:
             python3 -m twine upload --repository $repo dist/*
 
 jobs:
-  package-ubuntu:
+  package-manylinux1:
     environment:
       # PyPI authentication configuration for twine so we can upload packages.
       # TWINE_PASSWORD is set in the CircleCI private configuration section.
@@ -75,7 +75,7 @@ jobs:
       TWINE_USERNAME: "__token__"
 
     docker:
-      - image: "circleci/python:3.9"
+      - image: "quay.io/pypa/manylinux1_x86_64"
 
     steps:
       - "build-wheel"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,10 +263,12 @@ workflows:
             parameters:
               # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
               xcode-version:
-                # Latest macOS 10.x
+                # Latest macOS 10.15.x
                 - "12.4.0"
                 # Latest macOS 11.x
                 - "13.2.1"
+                # Just see if we can still have a 10.14.x
+                - "11.1.0"
           filters:
             # CircleCI does not run workflows for tags unless you explicitly
             # specify tag filters. Additionally, if a job requires any other

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,9 +252,6 @@ workflows:
       - "package-manylinux":
           name: "package-manylinux_2_24-aarch64"
           executor: "manylinux_2_24-aarch64"
-          install-ssh-client: |
-            sudo apt-get update -y
-            sudo apt-get install -y openssh-client
           python: "python3"
 
       - "package-macos":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
           command: |
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup-init
             sh /tmp/rustup-init -y --default-toolchain stable
-            . "$HOME"/.cargo/env
+            echo '. "$HOME"/.cargo/env' >> $BASH_ENV
 
       - run:
           name: "Get Python Build/Package Dependencies"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,10 @@
 version: 2.1
 
+executors:
+  manylinux-2014_x86_64:
+    docker:
+      - image: "quay.io/pypa/manylinux2014_x86_64"
+
 commands:
   build-wheel:
     parameters:
@@ -227,9 +232,7 @@ workflows:
       - "package-manylinux":
           name: "package-manylinux-2014_x86_64"
           python: "/opt/python/cp37-cp37m/bin/python"
-          executor:
-            docker:
-              - image: "quay.io/pypa/manylinux2014_x86_64"
+          executor: "manylinux-2014_x86_64"
 
       # - "package-manylinux":
       #     name: "package-manylinux_2_24-x86_64"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ workflows:
       - "package-manylinux":
           name: "package-manylinux_2_24-x86_64"
           executor: "manylinux_2_24-x86_64"
-          install-ssh-client: "apt-get install -y openssh-client"
+          install-ssh-client: "apt-get update -y && apt-get install -y openssh-client"
           python: "/opt/python/cp37-cp37m/bin/python"
       # - "package-manylinux":
       #     name: "package-manylinux_2_24-aarch64"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,12 +67,12 @@ commands:
             # to rely on whatever resolution logic setuptools would apply.
             << parameters.python >> -m pip install --upgrade milksnake setuptools_scm
             # And get these so we can build, fix, and upload a wheel.
-            << parameters.python >> -m pip install wheel twine auditwheel
+            << parameters.python >> -m pip install wheel auditwheel twine
 
       - run:
           name: "Build Wheel"
           command: |
-            << parameters.python >> -m pip wheel .
+            << parameters.python >> -m pip wheel --no-deps .
 
       - run:
           name: "Audix / Fix Wheel "

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,8 +99,7 @@ jobs:
             yum install -y openssh-clients
 
       - "build-wheel":
-          parameters:
-            python: "<< parameters.python >>"
+          python: "<< parameters.python >>"
 
   package-macos:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,7 @@
 version: 2.1
 
 jobs:
-  package-macos:
-    parameters:
-      xcode-version:
-        type: "string"
-
-    macos:
-      xcode: "<< parameters.xcode-version >>"
-
+  package-template: &PACKAGE_TEMPLATE
     environment:
       # PyPI authentication configuration for twine so we can upload packages.
       # TWINE_PASSWORD is set in the CircleCI private configuration section.
@@ -77,6 +70,24 @@ jobs:
               TWINE_PASSWORD="$TWINE_TESTPYPI_PASSWORD"
             fi
             python3 -m twine upload --repository $repo dist/*
+
+
+  package-ubuntu:
+    <<: *PACKAGE_TEMPLATE
+
+    docker:
+      - image: "circleci/python:3.9"
+
+  package-macos:
+    <<: *PACKAGE_TEMPLATE
+
+    parameters:
+      xcode-version:
+        type: "string"
+
+    macos:
+      xcode: "<< parameters.xcode-version >>"
+
 
   tests-template: &TESTS
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,13 +34,18 @@ commands:
             # Pre-install these two setup_depends using pip so we don't have
             # to rely on whatever resolution logic setuptools would apply.
             << parameters.python >> -m pip install --upgrade milksnake setuptools_scm
-            # And get these so we can build and then upload a wheel
-            << parameters.python >> -m pip install wheel twine
+            # And get these so we can build, fix, and upload a wheel.
+            << parameters.python >> -m pip install wheel twine auditwheel
 
       - run:
           name: "Build Wheel"
           command: |
             << parameters.python >> -m pip wheel .
+
+      - run:
+          name: "Audix / Fix Wheel "
+          command: |
+            << parameters.python >> -m auditwheel repair python_challenge_bypass_ristretto*.whl
 
       - run:
           name: "Upload Wheel"
@@ -56,7 +61,7 @@ commands:
               repo="testpypi"
               TWINE_PASSWORD="$TWINE_TESTPYPI_PASSWORD"
             fi
-            << parameters.python >> -m twine upload --repository $repo dist/*
+            << parameters.python >> -m twine upload --repository $repo python_challenge_bypass_ristretto*.whl
 
 jobs:
   package-manylinux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,6 +252,10 @@ workflows:
       - "package-manylinux":
           name: "package-manylinux_2_24-aarch64"
           executor: "manylinux_2_24-aarch64"
+          install-ssh-client: |
+            sudo apt-get update
+            # an auditwheel dependency that's not installed by default
+            sudo apt-get install patchelf
           python: "python3"
 
       - "package-macos":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,12 +77,16 @@ commands:
 jobs:
   package-manylinux:
     parameters:
-      python:
-        description: "The path to the Python executable to use"
-        type: "string"
-
       executor:
         type: "executor"
+
+      install-ssh-client:
+        description: "a command to install an SSH client prior to cloning git repositoties"
+        type: "string"
+
+      python:
+        description: "the path to the Python executable to use"
+        type: "string"
 
     environment:
       # PyPI authentication configuration for twine so we can upload packages.
@@ -111,9 +115,7 @@ jobs:
       - run:
           name: "Install SSH Client"
           command: |
-            if [ -e yum ]; then
-                yum install -y openssh-clients
-            fi
+            << parameters.install-ssh-client >>
 
       - "build-wheel":
           python: "<< parameters.python >>"
@@ -231,8 +233,9 @@ workflows:
       - "tests-2111"
       - "package-manylinux":
           name: "package-manylinux-2014_x86_64"
-          python: "/opt/python/cp37-cp37m/bin/python"
           executor: "manylinux-2014_x86_64"
+          install-ssh-client: "yum install -y openssh-clients"
+          python: "/opt/python/cp37-cp37m/bin/python"
 
       # - "package-manylinux":
       #     name: "package-manylinux_2_24-x86_64"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ executors:
   manylinux-2014_x86_64:
     docker:
       - image: "quay.io/pypa/manylinux2014_x86_64"
+  manylinux_2_24-x86_64:
+    docker:
+      - image: "quay.io/pypa/manylinux_2_24_x86_64"
 
 commands:
   build-wheel:
@@ -236,11 +239,10 @@ workflows:
           executor: "manylinux-2014_x86_64"
           install-ssh-client: "yum install -y openssh-clients"
           python: "/opt/python/cp37-cp37m/bin/python"
-
-      # - "package-manylinux":
-      #     name: "package-manylinux_2_24-x86_64"
-      #     image: "quay.io/pypa/manylinux_2_24_x86_64"
-      #     python: "/opt/python/cp37-cp37m/bin/python"
+      - "package-manylinux":
+          name: "package-manylinux_2_24-x86_64"
+          executor: "manylinux_2_24_x86_64"
+          python: "/opt/python/cp37-cp37m/bin/python"
       # - "package-manylinux":
       #     name: "package-manylinux_2_24-aarch64"
       #     image: "quay.io/pypa/manylinux_2_24_aarch64"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,13 +14,34 @@ executors:
 
 commands:
   build-wheel:
+    description: "Build a Python wheel"
+
     parameters:
       python:
         description: "The path to the Python executable to use"
         type: "string"
         default: "python3"
 
-    description: "Build a Python wheel"
+    environment:
+      # PyPI authentication configuration for twine so we can upload packages.
+      # TWINE_PASSWORD is set in the CircleCI private configuration section.
+      # In the CircleCI web app:
+      #
+      #    Project Settings ->
+      #    Environment Variables ->
+      #    Add Environment Variable ->
+      #    Name: TWINE_PASSWORD
+      #    Value: <a token issued by PyPI>
+      #
+      # The PyPI token is issued in the PyPI web app:
+      #
+      #    Manage ->
+      #    Settings ->
+      #    Create a token for ... ->
+      #    Permissions: Upload
+      #    Scope: Project: python-challenge-bypass-ristretto
+      TWINE_USERNAME: "__token__"
+
     steps:
       - "checkout"
       - run:
@@ -96,25 +117,6 @@ jobs:
         description: "the path to the Python executable to use"
         type: "string"
 
-    environment:
-      # PyPI authentication configuration for twine so we can upload packages.
-      # TWINE_PASSWORD is set in the CircleCI private configuration section.
-      # In the CircleCI web app:
-      #
-      #    Project Settings ->
-      #    Environment Variables ->
-      #    Add Environment Variable ->
-      #    Name: TWINE_PASSWORD
-      #    Value: <a token issued by PyPI>
-      #
-      # The PyPI token is issued in the PyPI web app:
-      #
-      #    Manage ->
-      #    Settings ->
-      #    Create a token for ... ->
-      #    Permissions: Upload
-      #    Scope: Project: python-challenge-bypass-ristretto
-      TWINE_USERNAME: "__token__"
 
     executor: "<< parameters.executor >>"
 
@@ -129,10 +131,6 @@ jobs:
           python: "<< parameters.python >>"
 
   package-macos:
-    environment:
-      # See package-manylinux2014_x86_64
-      TWINE_USERNAME: "__token__"
-
     parameters:
       xcode-version:
         type: "string"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ commands:
             python3 -m twine upload --repository $repo dist/*
 
 jobs:
-  package-manylinux2010:
+  package-manylinux2014_x86_64:
     environment:
       # PyPI authentication configuration for twine so we can upload packages.
       # TWINE_PASSWORD is set in the CircleCI private configuration section.
@@ -75,14 +75,14 @@ jobs:
       TWINE_USERNAME: "__token__"
 
     docker:
-      - image: "quay.io/pypa/manylinux2010_x86_64"
+      - image: "quay.io/pypa/manylinux2014_x86_64"
 
     steps:
       - "build-wheel"
 
   package-macos:
     environment:
-      # See package-manylinux2010
+      # See package-manylinux2014_x86_64
       TWINE_USERNAME: "__token__"
 
     parameters:
@@ -191,7 +191,7 @@ workflows:
     jobs:
       - "tests-2105"
       - "tests-2111"
-      - "package-manylinux2010"
+      - "package-manylinux2014_x86_64"
       - "package-macos":
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,8 +214,8 @@ workflows:
       - "package-manylinux":
           matrix:
             parameters:
-              - image: "quay.io/pypa/manylinux2014_x86_64"
-                python: "/opt/python/cp37-cp37m/bin/python"
+              image: "quay.io/pypa/manylinux2014_x86_64"
+              python: "/opt/python/cp37-cp37m/bin/python"
 
       - "package-macos":
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ commands:
       python:
         description: "The path to the Python executable to use"
         type: "string"
+        default: "python3"
 
     description: "Build a Python wheel"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,12 +173,18 @@ jobs:
     environment:
       NIXPKGS_REV: "21.05"
 
+  tests-2111:
+    <<: *TESTS
+    environment:
+      NIXPKGS_REV: "21.11"
+
 workflows:
   version: 2
   all-tests:
     jobs:
       - "tests-2009"
       - "tests-2105"
+      - "tests-2111"
       - "package-macos":
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,12 @@ jobs:
       - image: "quay.io/pypa/manylinux2014_x86_64"
 
     steps:
+      # The build needs SSH to update the submodule.
+      - run:
+          name: "Install SSH Client"
+          command: |
+            yum install -y openssh-clients
+
       - "build-wheel"
 
   package-macos:

--- a/challenge_bypass_ristretto/tests/test_privacypass.py
+++ b/challenge_bypass_ristretto/tests/test_privacypass.py
@@ -395,7 +395,7 @@ class TokenPreimageTests(TestCase):
 
 
 # The signature uses sha512.
-SIG_SIZE = 512 / 8
+SIG_SIZE = 512 // 8
 def verification_signatures():
     """
     Strategy that builds byte strings that are the right length to be

--- a/ci-tools/run-tests.sh
+++ b/ci-tools/run-tests.sh
@@ -2,11 +2,24 @@
 
 set -euxo pipefail
 
-# Run the ffi binding tests
-nix-build -A tests --out-link ffi-tests challenge-bypass-ristretto.nix
+# On CI, explicitly pass a value for nixpkgs so that the build respects the
+# nixpkgs revision CI is trying to test.  Otherwise, accept the default
+# nixpkgs defined by the packaging expressions.
+if [ -v CI ]; then
+    pkgsArg=(--arg pkgs "import <nixpkgs> {}")
+else
+    pkgsArg=()
+fi
+
+# Run the ffi binding tests.
+nix-build \
+    -A tests \
+    --out-link ffi-tests \
+    "${pkgsArg[@]}" \
+    challenge-bypass-ristretto.nix
 
 # Build the Python package itself
-nix-build --out-link result
+nix-build --out-link result "${pkgsArg[@]}"
 
 # Run what passes for the test suite for our Python code, too.  It would be
 # nice to put this into a tests attribute on the Python package derivation,

--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,7 @@ in
 , challenge-bypass-ristretto-ffi-repo ? sources.challenge-bypass-ristretto-ffi
 , challenge-bypass-ristretto-ffi ? pkgs.callPackage ./challenge-bypass-ristretto.nix { inherit challenge-bypass-ristretto-ffi-repo; }
 # Choose the Python runtime for which we're building
-, pythonPackages ? pkgs.python27Packages
+, pythonPackages ? pkgs.python39Packages
 }:
 # Build our Python bindings in the usual way, supplying the necessary extra
 # dependency.

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@ let
   sources = import nix/sources.nix;
 in
 { pkgs ? import sources.nixpkgs { }
-, python ? pkgs.python2
+, python ? pkgs.python39
 }:
 let
   challenge-bypass-ristretto-ffi = pkgs.callPackage ./challenge-bypass-ristretto.nix {


### PR DESCRIPTION
... and also stop testing Python 2 support

I also ended up mixing a lot of CircleCI configuration changes in here to do a better job of building wheels.  It's possible this wasn't strictly necessary but it doesn't end up making the PR diff *that* big so I guess I'm planning to leave it here (the history is, of course, the usual mess of "does it work now?" that you see with most cloud service configuration reconfigurations...).
