### PR TITLE
Prevent twine from trying to take user input on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,10 @@ commands:
             #    Scope: Project: python-challenge-bypass-ristretto
             TWINE_USERNAME: "__token__"
 
+            # Avoid twine trying to get user input from us.  It would just hang
+            # forever.
+            TWINE_NON_INTERACTIVE: "yes"
+
           command: |
             if [[ "$CIRCLE_TAG" == v* ]]; then
               # We're building a release tag so we should probably really


### PR DESCRIPTION
Fixes indefinite CI hangs on forked PRs
