### PR TITLE
Skip upload if credentials missing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,12 @@ commands:
               repo="testpypi"
               TWINE_PASSWORD="$TWINE_TESTPYPI_PASSWORD"
             fi
-            << parameters.python >> -m twine upload --repository $repo python_challenge_bypass_ristretto*.whl
+
+            if [ -n "${TWINE_PASSWORD}" ]; then
+              << parameters.python >> -m twine upload --repository $repo python_challenge_bypass_ristretto*.whl
+            else
+              echo "Package index credentials unavailable; skipping upload."
+            fi
 
 # Define the actual jobs that will be available to run in a workflow.
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,16 @@ commands:
           # And the rest of it.
           name: "Finish checking out source"
           command: |
+            # Some commands depend on the current system time (aaaaaaahh)!
+            # Record it for later inspection if necessary.
+            date
+
+            # libchallenge_bypass_ristretto is managed as a git submodule
+            # sometimes.
             git submodule init
             git submodule update
             git fetch --tags
+
 
       - run:
           name: "Install Rust Build Toolchain"


### PR DESCRIPTION
Currently builds from forked PRs fail when they get to the upload.  Try to skip it.
