### PR TITLE
CI: Don't build for aarch64/android

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,9 @@ workflows:
   all-tests:
     jobs:
       - "check"
-      - "build-aarch64-android"
+      # Don't build the aarch64 version for now - it takes forever,
+      # fails on CI, and we don't use it currently anyway.
+      # - "build-aarch64-android"
       - "build-native":
           matrix:
             parameters:


### PR DESCRIPTION
The aarch64/android build seems to never have worked, and comments in `flake.nix` seem to corroborate that.

It seems the cross-compile works, given enough resources - I have been building it now on my dev machine, but after 30 min it's still working on the cross-compile toolchain (llvm, clang, etc for aarch64) - it doesn't look like the CircleCI builders from the free plan could actually finish this build.

Disable it make CI green again.