### PR TITLE
Fix macOS wheels: drop `setuptools-scm`

### DIFF
--- a/nix/python-challenge-bypass-ristretto.nix
+++ b/nix/python-challenge-bypass-ristretto.nix
@@ -2,6 +2,8 @@
 # Ristretto implementation.
 { libchallenge_bypass_ristretto_ffi, python, pythonPackages, milksnake, cffi, attrs, testtools, hypothesis }:
 pythonPackages.buildPythonPackage rec {
+  # This version string should be kept in sync with the one declared in
+  # 'setup.py'
   version = "2024.11.5";
   pname = "python-challenge-bypass-ristretto";
   name = "${pname}-${version}";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,0 @@
-[build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8"]
-build-backend = "setuptools.build_meta"
-
-[project]
-name = "python-challenge-bypass-ristretto"
-dynamic = ["version"]
-
-[tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = ["setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
+name = "python-challenge-bypass-ristretto"
 dynamic = ["version"]
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
+build-backend = "setuptools.build_meta"
+
+[project]
+dynamic = ["version"]
+
+[tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -22,19 +22,12 @@ def readme():
     with open('README.md') as f:
         return f.read()
 
-def _myversion():
-    return dict(
-        # Unfortunately PyPI rejects package versions with a local part.
-        # Define a local scheme that never has a local part.
-        local_scheme=lambda version: "",
-    )
 
 setup(
     name='python-challenge-bypass-ristretto',
     packages=['challenge_bypass_ristretto', 'challenge_bypass_ristretto.tests'],
     zip_safe=False,
     platforms='any',
-    # setup_requires=['milksnake', 'setuptools_scm'],
     version='2024.11.5',
     setup_requires=['milksnake'],
     install_requires=['cffi', 'attrs'],
@@ -44,7 +37,6 @@ setup(
             "hypothesis",
         ],
     },
-    # use_scm_version=_myversion,
     url='https://github.com/LeastAuthority/python-challenge-bypass-ristretto',
     milksnake_tasks=[
         build_native

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setup(
     packages=['challenge_bypass_ristretto', 'challenge_bypass_ristretto.tests'],
     zip_safe=False,
     platforms='any',
+    # This version string should be kept in sync with the one declared in
+    # 'nix/python-challenge-bypass-ristretto.nix'
     version='2024.11.5',
     setup_requires=['milksnake'],
     install_requires=['cffi', 'attrs'],

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,9 @@ setup(
     packages=['challenge_bypass_ristretto', 'challenge_bypass_ristretto.tests'],
     zip_safe=False,
     platforms='any',
-    setup_requires=['milksnake', 'setuptools_scm'],
+    # setup_requires=['milksnake', 'setuptools_scm'],
+    version='2024.11.5',
+    setup_requires=['milksnake'],
     install_requires=['cffi', 'attrs'],
     extras_require={
         "tests": [
@@ -42,7 +44,7 @@ setup(
             "hypothesis",
         ],
     },
-    use_scm_version=_myversion,
+    # use_scm_version=_myversion,
     url='https://github.com/LeastAuthority/python-challenge-bypass-ristretto',
     milksnake_tasks=[
         build_native


### PR DESCRIPTION
This PR removes the use of `setuptools-scm` in favor of declaring a hardcoded version string, effectively fixing the failing (macOS) wheel builds. Builds had been failing previously because newer versions of `setuptools-scm` can no longer be configured via `setup.py` (and must use `pyproject.toml`).

This is not ideal solution: in keeping up with recent changes in the Python packaging ecosystem, it would be preferable to shift project configuration from `setup.py` to `pyproject.toml`, _however_, this project's `setup.py` currently contains custom/milksnake-specific hooks that would presumably be need to re-implemented elsewhere (and is beyond the scope of this PR).

Note that a version string was already being hardcoded in `nix/python-challenge-bypass-ristretto.nix` (so `setuptools-scm` could not have been used to handle any/all version-string declaration anyway). I've documented this in a comment in both files; future maintainers should update the version string in both places until the entire project can be migrated to using `pyproject.toml`.